### PR TITLE
Add AI instructor search script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@
 chichinliu/chichinliu is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## search_ai_instructors.py
+
+This simple script queries DuckDuckGo to find webpages related to qualified AI course instructors. It requires the `requests` library.
+
+```bash
+python3 search_ai_instructors.py "AI \u8ab2\u7a0b \u5408\u683c \u5e2b\u8cc7" -n 5
+```
+
+The script will print the top search results.
+

--- a/search_ai_instructors.py
+++ b/search_ai_instructors.py
@@ -1,0 +1,43 @@
+import requests
+import argparse
+
+
+def search(query, limit=5):
+    params = {
+        "q": query,
+        "format": "json",
+        "no_html": "1",
+        "skip_disambig": "1"
+    }
+    resp = requests.get("https://api.duckduckgo.com/", params=params)
+    resp.raise_for_status()
+    data = resp.json()
+
+    results = []
+    for item in data.get('RelatedTopics', []):
+        if 'FirstURL' in item and 'Text' in item:
+            results.append({'url': item['FirstURL'], 'text': item['Text']})
+        elif 'Topics' in item:
+            for sub in item['Topics']:
+                if 'FirstURL' in sub and 'Text' in sub:
+                    results.append({'url': sub['FirstURL'], 'text': sub['Text']})
+        if len(results) >= limit:
+            break
+    return results[:limit]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search for qualified AI course instructors")
+    parser.add_argument('keywords', nargs='*', default=["AI", "\u8ab2\u7a0b", "\u5408\u683c", "\u5e2b\u8cc7"],
+                        help='Search keywords (default: AI \u8ab2\u7a0b \u5408\u683c \u5e2b\u8cc7)')
+    parser.add_argument('-n', '--num', type=int, default=5, help='Number of results to return')
+    args = parser.parse_args()
+    query = ' '.join(args.keywords)
+    results = search(query, args.num)
+    print(f"Top {len(results)} results for: {query}")
+    for i, res in enumerate(results, 1):
+        print(f"{i}. {res['text']}\n   {res['url']}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `search_ai_instructors.py` for searching web results about AI course instructors via DuckDuckGo
- document usage in README

## Testing
- `python3 search_ai_instructors.py "AI 課程 合格 師資" -n 3` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683fcd658acc832e8a17aae026148f03